### PR TITLE
Update for ClickMeetingRestClient.rb - fixing example

### DIFF
--- a/API/examples/Ruby/ClickMeetingRestClient.rb
+++ b/API/examples/Ruby/ClickMeetingRestClient.rb
@@ -100,7 +100,7 @@ module ClickMeeting
         end
         
         def conferences(status = 'active', page = 1)
-            sendRequest('GET', 'conferences/' + status + '?page=' + page)
+            sendRequest('GET', 'conferences/' + status + '?page=' + page.to_s)
         end
     
         def conference(room_id)


### PR DESCRIPTION
Fix for ruby example, we need cast page variable to string.